### PR TITLE
fix: spectator switch bug

### DIFF
--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/Tablist.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/Tablist.java
@@ -9,9 +9,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
 
 public class Tablist {
 
+    private final @NonNull Logger logger;
     private final @NonNull TablistService tablistService;
     private final @NonNull ServerDataProvider serverDataProvider;
     private final @NonNull List<String> headerFormatStrings;
@@ -30,20 +33,21 @@ public class Tablist {
      * @param footerFormatStrings a list containing the tablist's footer
      * @param sortType            the tablist's sorting type
      */
-    public Tablist(final @NonNull TablistService tablistService,
+    public Tablist(final @NonNull Logger logger,
+                   final @NonNull TablistService tablistService,
                    final @NonNull ServerDataProvider serverDataProvider,
                    final @NonNull List<String> headerFormatStrings,
                    final @NonNull List<String> footerFormatStrings,
                    final @NonNull SortType sortType,
                    final @NonNull List<String> serverSortPriorities,
                    final @NonNull List<String> groupSortPriorities) {
+        this.logger = logger;
         this.tablistService = tablistService;
         this.serverDataProvider = serverDataProvider;
         this.headerFormatStrings = headerFormatStrings;
         this.footerFormatStrings = footerFormatStrings;
         this.serverSortPriorities = serverSortPriorities;
         this.groupSortPriorities = groupSortPriorities;
-
         this.sortType = sortType;
         this.profileEntries = new ArrayList<>();
     }
@@ -64,17 +68,17 @@ public class Tablist {
      */
     public @NonNull List<TabListEntry> entries(final @NonNull TabList tabList) {
         return profileEntries
-            .stream()
-            .sorted(Comparator.comparing(GameProfile::getName))
-            .map(gameProfile -> 
-                TabListEntry.builder()
-                    .latency(10)
-                    .tabList(tabList)
-                    .profile(gameProfile)
-                    .displayName(this.tablistService.displayName(gameProfile.getId()))
-                    .gameMode(0)
-                    .build()
-            ).toList();
+                .stream()
+                .sorted(Comparator.comparing(GameProfile::getName))
+                .map(gameProfile ->
+                        TabListEntry.builder()
+                                .latency(10)
+                                .tabList(tabList)
+                                .profile(gameProfile)
+                                .displayName(this.tablistService.displayName(gameProfile.getId()))
+                                .gameMode(this.getGameMode(tabList, gameProfile.getId()))
+                                .build()
+                ).toList();
     }
 
     private void insert(final @NonNull GameProfile gameProfile) {
@@ -92,4 +96,18 @@ public class Tablist {
     public @NonNull SortType sortType() {
         return this.sortType;
     }
+
+    private int getGameMode(final @NonNull TabList tabList,
+                            final @NonNull UUID uuid) {
+        for (final TabListEntry entry : tabList.getEntries()) {
+            if (entry.getProfile().getId().equals(uuid)) {
+                return entry.getGameMode();
+            }
+        }
+
+        this.logger.warning(String.format("Failed to determine GameMode for %s! Returning: 0", uuid));
+
+        return 0;
+    }
+
 }

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/TablistService.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/TablistService.java
@@ -106,7 +106,7 @@ public class TablistService {
             final String id = entry.getKey();
             final TablistConfig tablistConfig = entry.getValue();
             final Tablist tablist = new Tablist(
-                    this, this.serverDataProvider,
+                    this.logger, this, this.serverDataProvider,
                     tablistConfig.headerFormatStrings,
                     tablistConfig.footerFormatStrings,
                     tablistConfig.sortType,


### PR DESCRIPTION
This PR fixes the spectator switch bug.

Previously, TabListEntry instances were constructed with the assumed value of `0` for the gamemode. If the tablist were to update while the player was in gamemode `3` (spectator), setting the client's gamemode to `0` causes a desync occur between the backend server and client, where the client believes it is in survival, but the server is sending packets as if the player were in spectator.

This code has been switched to read from the proxy's TabList object, which will contain the latest gamemode information the proxy has access to. If a player's gamemode cannot be read from Velocity, `0` is used (Survival mode), and a log message is printed. 