### PR TITLE
feat: remove hard-depend on LuckPerms

### DIFF
--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/BatVelocityPlugin.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/BatVelocityPlugin.java
@@ -3,6 +3,7 @@ package com.nearvanilla.bat.velocity;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.nearvanilla.bat.velocity.command.Commands;
+import com.nearvanilla.bat.velocity.listener.LuckPermsListener;
 import com.nearvanilla.bat.velocity.tab.TablistService;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
@@ -10,7 +11,6 @@ import com.velocitypowered.api.event.player.ServerPostConnectEvent;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
-import net.luckperms.api.event.user.UserDataRecalculateEvent;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
@@ -64,16 +64,15 @@ public class BatVelocityPlugin {
         this.tablistService.handlePlayerLeave(event.getPlayer());
     }
 
-    @Subscribe
-    public void onGroupChange(final @NonNull UserDataRecalculateEvent event) {
-        server.getPlayer(event.getUser().getUniqueId())
-                .ifPresent(value -> this.tablistService.handleServerConnection(value));
-    }
-
     public void enable() {
         this.tablistService = this.injector.getInstance(TablistService.class);
         this.tablistService.enable();
+
         this.commands = this.injector.getInstance(Commands.class);
         this.commands.register();
+
+        if (this.server.getPluginManager().isLoaded("LuckPerms")) {
+            this.server.getEventManager().register(this, this.injector.getInstance(LuckPermsListener.class));
+        }
     }
 }

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/listener/LuckPermsListener.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/listener/LuckPermsListener.java
@@ -1,0 +1,27 @@
+package com.nearvanilla.bat.velocity.listener;
+
+import com.google.inject.Inject;
+import com.nearvanilla.bat.velocity.tab.TablistService;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.luckperms.api.event.user.UserDataRecalculateEvent;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class LuckPermsListener {
+
+    private final @NonNull ProxyServer server;
+    private final @NonNull TablistService tablistService;
+
+    @Inject
+    public LuckPermsListener(final @NonNull ProxyServer server,
+                             final @NonNull TablistService tablistService) {
+        this.server = server;
+        this.tablistService = tablistService;
+    }
+
+    @Subscribe
+    public void onGroupChange(final @NonNull UserDataRecalculateEvent event) {
+        server.getPlayer(event.getUser().getUniqueId()).ifPresent(this.tablistService::handleServerConnection);
+    }
+
+}

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/ServerDataProvider.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/ServerDataProvider.java
@@ -1,12 +1,16 @@
 package com.nearvanilla.bat.velocity.tab;
 
 import com.nearvanilla.bat.velocity.BatVelocityPlugin;
+import com.nearvanilla.bat.velocity.tab.group.EmptyGroupProvider;
+import com.nearvanilla.bat.velocity.tab.group.GroupProvider;
+import com.nearvanilla.bat.velocity.tab.group.LuckPermsGroupProvider;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import net.kyori.adventure.text.Component;
+import net.luckperms.api.LuckPermsProvider;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import javax.inject.Inject;
@@ -25,6 +29,7 @@ public class ServerDataProvider {
     private final @NonNull Map<String, ServerPing> pingMap;
     private final @NonNull Map<UUID, Integer> playerPingMap;
     private final @NonNull ScheduledTask updateTask;
+    private final @NonNull GroupProvider groupProvider;
 
     @Inject
     public ServerDataProvider(final @NonNull ProxyServer server,
@@ -37,6 +42,20 @@ public class ServerDataProvider {
                 .buildTask(this.plugin, this::update)
                 .repeat(5L, TimeUnit.SECONDS)
                 .schedule();
+        if (this.server.getPluginManager().isLoaded("luckperms")) {
+            this.groupProvider = new LuckPermsGroupProvider(LuckPermsProvider.get());
+        } else {
+            this.groupProvider = new EmptyGroupProvider();
+        }
+    }
+
+    /**
+     * Returns the {@link GroupProvider}.
+     *
+     * @return the {@link GroupProvider}
+     */
+    public @NonNull GroupProvider groupProvider() {
+        return this.groupProvider;
     }
 
     /**

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/Tablist.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/Tablist.java
@@ -48,37 +48,43 @@ public class Tablist {
         this.profileEntries = new ArrayList<>();
     }
 
+    /**
+     * Adds a player to the tablist.
+     *
+     * @param player the player
+     */
     public void addPlayer(final @NonNull Player player) {
-        this.insert(player.getGameProfile());
+        this.profileEntries.add(player.getGameProfile());
     }
 
+    /**
+     * Removes the player from the tablist.
+     *
+     * @param player the player
+     */
     public void removePlayer(final @NonNull Player player) {
         this.profileEntries.removeIf(profile -> profile.getId().equals(player.getUniqueId()));
     }
 
     /**
-     * Generates {@link TabListEntry} for the tablist.
+     * Generates a list of {@link TabListEntry}s for the tablist.
      *
      * @param tabList the tablist
      * @return the list of tablist entries
      */
     public @NonNull List<TabListEntry> entries(final @NonNull TabList tabList) {
         return profileEntries
-            .stream()
-            .sorted(Comparator.comparing(GameProfile::getName))
-            .map(gameProfile -> 
-                TabListEntry.builder()
-                    .latency(10)
-                    .tabList(tabList)
-                    .profile(gameProfile)
-                    .displayName(this.tablistService.displayName(gameProfile.getId()))
-                    .gameMode(0)
-                    .build()
-            ).toList();
-    }
-
-    private void insert(final @NonNull GameProfile gameProfile) {
-        this.profileEntries.add(gameProfile);
+                .stream()
+                .sorted(Comparator.comparing(GameProfile::getName))
+                .map(gameProfile ->
+                        TabListEntry.builder()
+                                .latency(10)
+                                .tabList(tabList)
+                                .profile(gameProfile)
+                                .displayName(this.tablistService.displayName(gameProfile.getId()))
+                                .gameMode(3)
+                                .build()
+                ).toList();
     }
 
     public @NonNull List<String> headerFormatStrings() {

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/group/EmptyGroupProvider.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/group/EmptyGroupProvider.java
@@ -1,0 +1,19 @@
+package com.nearvanilla.bat.velocity.tab.group;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * {@code EmptyGroupProvider} returns an empty {@link Collection} when queried.
+ */
+public class EmptyGroupProvider implements GroupProvider {
+
+    @Override
+    public @NonNull Collection<String> groups(final @NonNull UUID uuid) {
+        return List.of();
+    }
+
+}

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/group/GroupProvider.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/group/GroupProvider.java
@@ -1,0 +1,21 @@
+package com.nearvanilla.bat.velocity.tab.group;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * {@code GroupProvider} defines methods to retrieve a user's inherited and primary groups.
+ */
+public interface GroupProvider {
+
+    /**
+     * Returns a {@link Collection} containing the IDs of all groups a player is a member of.
+     *
+     * @param uuid the uuid of a player
+     * @return a {@link Collection}, will be empty if there is no group data for the provided {@link UUID}
+     */
+    @NonNull Collection<String> groups(final @NonNull UUID uuid);
+
+}

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/group/LuckPermsGroupProvider.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/group/LuckPermsGroupProvider.java
@@ -1,0 +1,53 @@
+package com.nearvanilla.bat.velocity.tab.group;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.query.Flag;
+import net.luckperms.api.query.QueryOptions;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+/**
+ * {@code LuckPermsGroupProvider} utilizes the {@link LuckPerms} API to retrieve a user's group information.
+ */
+public class LuckPermsGroupProvider implements GroupProvider {
+
+    private final @NonNull LuckPerms luckPerms;
+
+    /**
+     * Constructs {@code LuckPermsGroupProvider}.
+     *
+     * @param luckPerms the {@link LuckPerms} API instance
+     */
+    public LuckPermsGroupProvider(final @NonNull LuckPerms luckPerms) {
+        this.luckPerms = luckPerms;
+    }
+
+    /**
+     * Returns a player's groups.
+     *
+     * @param uuid the uuid
+     * @return the collection of group names
+     */
+    @Override
+    public @NonNull Collection<String> groups(final @NonNull UUID uuid) {
+        final User user = this.luckPerms.getUserManager().getUser(uuid);
+
+        if (user == null) {
+            return new ArrayList<>();
+        }
+
+        return user.getInheritedGroups(QueryOptions.defaultContextualOptions().toBuilder().flag(Flag.RESOLVE_INHERITANCE, true).build())
+                .stream()
+                .map(Group::getName)
+                .toList();
+    }
+
+
+}


### PR DESCRIPTION
This PR extracts the use of LuckPerms' API to read user groups into the `GroupProvider` interface. At runtime, the plugin determines which `GroupProvider` implementation to use depending on the enabled plugin. This allows bat to be used without LuckPerms, and opens the door to future integrations with other permissions software.