### PR TITLE
Set real latency

### DIFF
--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/Tablist.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/Tablist.java
@@ -85,7 +85,7 @@ public class Tablist {
                 .sorted(Comparator.comparing(GameProfile::getName))
                 .map(gameProfile ->
                         TabListEntry.builder()
-                                .latency(10)
+                                .latency(this.tablistService.ping(gameProfile.getId()))
                                 .tabList(tabList)
                                 .profile(gameProfile)
                                 .displayName(this.tablistService.displayName(gameProfile.getId()))

--- a/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/TablistService.java
+++ b/velocity/src/main/java/com/nearvanilla/bat/velocity/tab/TablistService.java
@@ -346,4 +346,9 @@ public class TablistService {
         }
     }
 
+    public int ping(final @NonNull UUID uuid) {
+        final Optional<Player> player = server.getPlayer(uuid);
+        return player.map(Player::getPing).orElse(-1L).intValue();
+    }
+
 }


### PR DESCRIPTION
Closes #20

[Not setting](https://github.com/PaperMC/Velocity/blob/7d77bfb53ced3b41dc76036797ee370eab931a00/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java#L127) the latency will always result in [5 bars](https://github.com/PaperMC/Velocity/blob/7d77bfb53ced3b41dc76036797ee370eab931a00/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java#L63-L68)

From testing on a localhost server for a second or 2 it'll show the no connection icon but that might be because I'm on a localhost server