### PR TITLE
Minor README improvement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Basic, awesome TAB plugin.
 
 - Java 16+
 - The latest **development** version of Velocity *(This plugin does not work on the Stable version!)*
+- Git (This is only required if you intend on cloning the repository through your Terminal)
 
 #### Compilation
 
-- Clone this repository to a directory of your choice through running `git clone https://github.com/NearVanilla/bat.git` in your terminal.
+- Clone this repository to a directory of your choice through running `git clone https://github.com/NearVanilla/bat.git` in your terminal. Alternatively, you can download this repository as a ZIP at the top of this page.
 - Change your directory to the `bat` folder through running `cd bat`
 - Run `gradlew build` to compile the project *(Ensure you have the correct version of Java)*.
 - Navigate to the `libs` folder inside of the newly created `build` folder in your File Explorer.


### PR DESCRIPTION
I added Git as an optional requirement, which would be needed if the user intended on cloning the repository through their Terminal. It is not a requirement if the user decides to download the repository through their browser (That has also been mentioned).

Not sure if this is actually needed but it would make things slightly clearer for people who aren't as experienced.